### PR TITLE
fix: no camera fix, for screen sharing only

### DIFF
--- a/public/js/broadcast.js
+++ b/public/js/broadcast.js
@@ -381,7 +381,7 @@ function toggleVideo() {
 // Handle share screen
 // =====================================================
 
-if (!isMobileDevice && (navigator.getDisplayMedia || navigator.mediaDevices.getDisplayMedia)) {
+if (!isMobileDevice && (navigator.getDisplayMedia || (navigator.mediaDevices && navigator.mediaDevices.getDisplayMedia))) {
     screenShareStart.addEventListener('click', toggleScreen);
     screenShareStop.addEventListener('click', toggleScreen);
 } else {

--- a/public/js/utils.js
+++ b/public/js/utils.js
@@ -84,11 +84,13 @@ function getUUID4() {
 }
 
 function hasAudioTrack(mediaStream) {
+if(!mediaStream) return false
     const audioTracks = mediaStream.getAudioTracks();
     return audioTracks.length > 0;
 }
 
 function hasVideoTrack(mediaStream) {
+    if(!mediaStream) return false
     const videoTracks = mediaStream.getVideoTracks();
     return videoTracks.length > 0;
 }


### PR DESCRIPTION
When there is no camera, no microphone, screen sharing will fail. 
Only fix screen sharing without such a device